### PR TITLE
Version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 1.3.0
+
+### ➕ Added
+
+**DataTable:**
+- Added responsive mode to `DataTable`
+  - Added `omitFromSmall` prop to `DataTable` column. This will omit the column when rendered on small devices.
+  - Added `spanSmall` prop to `DataTable` column. When `true`, this will omit the column header when rendered on small devices and render the value full width.
+
+**Flex:**
+- Added `grow` prop to `Flex`
+
+### 📝 Changed
+
+**DataTable:**
+- Changed signature for datatable column renderer
+
+**Core:**
+- Some minor moves and cleanups
+
+---
+
+<!---
+Changelog template:
+
+## 0.0.X
+#### ➕ Added
+ This was added
+#### 📝 Changed
+ This was changed
+#### 🐞 Fixed
+ This was fixed
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 **Flex:**
 - Added `grow` prop to `Flex`
 
+**Overlay**
+- Added `onBackgroundClick`
+
 ### 📝 Changed
 
 **DataTable:**

--- a/index.tsx
+++ b/index.tsx
@@ -31,7 +31,7 @@ import {
 } from './src/components/CheckBox/CheckBox';
 import { CheckBoxList, CheckBoxListProps } from './src/components/CheckBoxList/CheckBoxList';
 import { Drawer, DrawerProps } from './src/components/Drawer/Drawer';
-import { DataTable, DataTableProps } from './src/components/Table/DataTable';
+import { DataTable } from './src/components/Table/DataTable';
 import { Empty, EmptyProps } from './src/components/Empty/Empty';
 import { FormGroup, FormGroupProps } from './src/components/FormGroup/FormGroup';
 import { Flex, FlexProps } from './src/components/Flex/Flex';
@@ -88,7 +88,7 @@ import { Toast, ToastProps } from './src/components/Toast/Toast';
 import { Toggle, ToggleProps, ToggleSize } from './src/components/Toggle/Toggle';
 import { CustomComponent, GenericSizes, Omit } from './src/components/common';
 import { TabType } from './src/components/TabControl/TabControlTypes';
-import { Column } from './src/components/Table/TableTypes';
+import { Column, DataTableProps } from './src/components/Table/TableTypes';
 
 export {
   FontAwesomeIconProps,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joachimdalen/devui",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "",
   "main": "build/main.js",
   "types": "build/index.d.ts",

--- a/src/components/Flex/Flex.scss
+++ b/src/components/Flex/Flex.scss
@@ -86,4 +86,7 @@
       align-items: stretch;
     }
   }
+  &-grow {
+    flex-grow: 1;
+  }
 }

--- a/src/components/Flex/Flex.tsx
+++ b/src/components/Flex/Flex.tsx
@@ -12,6 +12,7 @@ export interface FlexProps {
   wrap?: FlexWrap;
   justify?: FlexJustify;
   align?: FlexAlign;
+  grow?: boolean;
   flexDirection?: FlexDirection;
   children: any;
   className?: string;
@@ -68,6 +69,7 @@ const getAlignClass = (align?: FlexAlign): string => {
 export const Flex = ({
   gap,
   flexDirection = 'row',
+  grow = false,
   wrap,
   justify,
   align,
@@ -77,6 +79,7 @@ export const Flex = ({
   const classes = cx(
     'dui-flex',
     { [`dui-flex-gap-${gap}`]: gap !== undefined },
+    { [`dui-flex-grow`]: grow },
     [`dui-flex-${flexDirection}`],
     getWrapClass(wrap),
     getJustifyClass(justify),

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -6,16 +6,24 @@ export interface OverlayProps {
   visible: boolean;
   backgroundColor?: string;
   children?: React.ReactNode;
+  onBackgroundClick?: () => void;
 }
 export const Overlay: React.FunctionComponent<OverlayProps> = ({
   children,
   visible,
   className,
-  backgroundColor
+  backgroundColor,
+  onBackgroundClick
 }: OverlayProps) => {
   const baseClass = cx('dui-overlay', className);
   return visible ? (
-    <div className={baseClass} style={{ backgroundColor: backgroundColor }}>
+    <div
+      className={baseClass}
+      style={{ backgroundColor: backgroundColor }}
+      onClick={() => {
+        if (onBackgroundClick) onBackgroundClick();
+      }}
+    >
       {children}
     </div>
   ) : null;

--- a/src/components/Table/DataTable.tsx
+++ b/src/components/Table/DataTable.tsx
@@ -18,8 +18,6 @@ interface DataTableState {
 }
 
 export class DataTable extends React.Component<DataTableProps, DataTableState> {
-  _mediaMatch: MediaQueryList;
-
   state = {
     checked: [] as any[],
     sortBy: {} as Column,
@@ -38,42 +36,36 @@ export class DataTable extends React.Component<DataTableProps, DataTableState> {
     )
   };
 
+  updateScreenSize = (): void => {
+    const { isSmall } = this.state;
+    const { smallBreakPoint } = this.props;
+    if (window.innerWidth <= (smallBreakPoint || 400) && !isSmall) {
+      this.setState({ isSmall: true });
+    }
+    if (
+      window.innerWidth >= (smallBreakPoint === undefined ? 400 : smallBreakPoint + 1) &&
+      isSmall
+    ) {
+      this.setState({ isSmall: false });
+    }
+  };
   componentDidMount(): void {
     const { responsive } = this.props;
     if (responsive) {
-      this._setSmallTableHandler();
+      window.addEventListener('resize', this.updateScreenSize);
     }
+  }
+  componentWillUnmount(): void {
+    window.removeEventListener('resize', this.updateScreenSize);
   }
 
   componentDidUpdate(prevProps: DataTableProps, prevState: DataTableState): void {
     if (prevProps.responsive && !this.props.responsive) {
-      console.log('Removed event listener');
-      this._mediaMatch?.removeEventListener('change', e => this._setSmallTable(e));
-    }
-
-    if (!prevProps.responsive && this.props.responsive && this._mediaMatch === undefined) {
-      this._setSmallTableHandler();
-    }
-  }
-
-  _setSmallTableHandler(): void {
-    const { responsive, smallBreakPoint } = this.props;
-    if (responsive) {
-      const matchOn = smallBreakPoint || 'max-width: 400px';
-      this._mediaMatch = window.matchMedia(`(${matchOn})`);
-      this._mediaMatch.addEventListener('change', e => this._setSmallTable(e));
-      console.log('Added event listener');
-    }
-  }
-  _setSmallTable(event: MediaQueryListEvent): void {
-    if (event.matches && !this.state.isSmall) {
-      console.log('Toggled On');
-      this.setState({ isSmall: true });
-    }
-
-    if (!event.matches && this.state.isSmall) {
-      console.log('Toggled Off');
       this.setState({ isSmall: false });
+      window.removeEventListener('resize', this.updateScreenSize);
+    }
+    if (!prevProps.responsive && this.props.responsive) {
+      window.addEventListener('resize', this.updateScreenSize);
     }
   }
 

--- a/src/components/Table/SmallTable.stories.tsx
+++ b/src/components/Table/SmallTable.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { Button } from '../Button/Button';
 import { FontAwesomeIcon } from '../FontAwesomeIcon/FontAwesomeIcon';
-import { DataTable } from './DataTable';
+import { SmallTable } from './SmallTable';
 import { Column, DataTableProps } from './TableTypes';
 const columnHeaders: Column[] = [
   {
@@ -15,7 +15,8 @@ const columnHeaders: Column[] = [
   {
     key: 'created',
     label: 'Created',
-    sortable: true
+    sortable: true,
+    omitFromSmall: true
   },
   {
     key: 'status',
@@ -57,33 +58,34 @@ const columnHeaders: Column[] = [
     key: 'amount',
     label: 'Amount',
     sortable: true,
-    renderer: (item: any) => (
-      <span>
-        <FontAwesomeIcon iconStyle="solid" icon="fa-dollar-sign" className="dui-color-success" />{' '}
-        {item.amount.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')}
-      </span>
-    )
+    renderer: (item: any, c, r, isSmall: boolean) =>
+      isSmall ? (
+        item.amount
+      ) : (
+        <span>
+          <FontAwesomeIcon iconStyle="solid" icon="fa-dollar-sign" className="dui-color-success" />{' '}
+          {item.amount.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')}
+        </span>
+      )
   },
   {
     key: 'actions',
     label: '',
     spanSmall: true,
     renderer: (item: any, c, r, isSmall: boolean) => {
-      return <Button format="block" label="Delete" variant="danger" linkButton={isSmall}></Button>;
+      return <Button format="block" label="Click"></Button>;
     }
   }
 ];
 export default {
-  title: 'Display Components/Table/Table',
-  component: DataTable,
+  title: 'Display Components/Table/Small Table',
+  component: SmallTable,
   args: {
     columns: columnHeaders,
-    rows: require('../../../data/invoices.json'),
-    responsive: true,
-    smallBreak: 'max-width: 400px'
+    rows: require('../../../data/invoices.json')
   }
 } as Meta;
 
-const BaseTemplate: Story<DataTableProps> = args => <DataTable {...args} />;
+const BaseTemplate: Story<DataTableProps> = args => <SmallTable {...args} />;
 
 export const Default: Story<DataTableProps> = BaseTemplate.bind({});

--- a/src/components/Table/SmallTable.tsx
+++ b/src/components/Table/SmallTable.tsx
@@ -1,0 +1,66 @@
+import cx from 'classnames';
+import * as React from 'react';
+
+import { Flex } from '../Flex/Flex';
+import { Column, DataTableProps } from './TableTypes';
+
+export class SmallTable extends React.Component<DataTableProps> {
+  _getRow(row: any, rowIndex: number): React.ReactElement {
+    const { rowKey, columns } = this.props;
+    const renderedRows =
+      row &&
+      (columns
+        ?.filter((col: Column) => col.omitFromSmall === false || col.omitFromSmall === undefined)
+        .map((col: Column, i: number) => {
+          const cellValue = col.renderer
+            ? col.renderer(row, i, rowIndex, true)
+            : col.accessor
+            ? col.accessor(row)
+            : row[col.key];
+          const omitHeader = !(col.spanSmall === undefined || col.spanSmall === false);
+          return (
+            <Flex key={rowKey ? row[rowKey] : `row-item-${rowIndex}-${i}`} gap="small">
+              {!omitHeader && (
+                <Flex grow>
+                  <span className="dui-table-small-cell dui-table-small-header" key={col.key}>
+                    {col.label}
+                  </span>
+                </Flex>
+              )}
+              <Flex grow={omitHeader}>
+                <span
+                  className={cx(col.className, 'dui-table-small-cell')}
+                  key={rowKey ? row[rowKey] : `row-item-cell-${i}`}
+                >
+                  {cellValue}
+                </span>
+              </Flex>
+            </Flex>
+          );
+        }) as any);
+
+    return renderedRows;
+  }
+
+  render(): React.ReactElement {
+    const { rows, emptyComp, showEmpty, striped } = this.props;
+    const emptyItem = showEmpty ? emptyComp : null;
+    const shouldShowEmpty = !rows || rows.length === 0;
+    return (
+      <Flex
+        className={cx('dui-table-small', { 'dui-table-small-striped': striped })}
+        flexDirection="column"
+        gap="small"
+      >
+        {rows.map((row, index) => {
+          return (
+            <Flex key={row?.key} flexDirection="column" className="dui-table-section">
+              {this._getRow(row, index) as any}
+            </Flex>
+          );
+        })}
+        {shouldShowEmpty && emptyItem}
+      </Flex>
+    );
+  }
+}

--- a/src/components/Table/SmallTable.tsx
+++ b/src/components/Table/SmallTable.tsx
@@ -50,7 +50,6 @@ export class SmallTable extends React.Component<DataTableProps> {
       <Flex
         className={cx('dui-table-small', { 'dui-table-small-striped': striped })}
         flexDirection="column"
-        gap="small"
       >
         {rows.map((row, index) => {
           return (

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -97,4 +97,34 @@
       cursor: pointer;
     }
   }
+  &-small {
+    font-size: $table-font-size;
+    color: $table-color;
+    border-collapse: collapse;
+    background-color: $table-background;
+    .#{$provider-prefix}-table-section {
+      border: $table-border-width solid $table-border-color;
+      > .dui-flex {
+        padding: 5px;
+      }
+    }
+    &-cell {
+      width: 100%;
+      padding: $table-cell-padding;
+      font-size: $table-row-header-font-size;
+      line-height: 1.5;
+    }
+    &-header {
+      font-size: $table-row-header-font-size;
+      font-weight: $table-row-header-font-weight;
+      line-height: 1.5;
+      color: $table-row-header-color;
+    }
+    &-striped {
+      .dui-table-section > .#{$provider-prefix}-flex:nth-child(2n) {
+        color: $table-striped-color;
+        background-color: $table-striped-background;
+      }
+    }
+  }
 }

--- a/src/components/Table/TableTypes.tsx
+++ b/src/components/Table/TableTypes.tsx
@@ -1,3 +1,6 @@
+import { Omit } from '../common';
+import { Empty } from '../Empty/Empty';
+import { TableProps } from './Table';
 import { TableRow } from './TableRow';
 
 export interface Column {
@@ -6,7 +9,26 @@ export interface Column {
   sortable?: boolean;
   forceVisible?: boolean;
   accessor?: (item: any) => string;
-  renderer?: (item: any, index?: number) => React.ReactNode;
+  renderer?: (
+    item: any,
+    columnIndex?: number,
+    rowIndex?: number,
+    isSmall?: boolean
+  ) => React.ReactNode;
   onSort?: (a: TableRow, b: TableRow) => number;
   className?: string;
+  omitFromSmall?: boolean;
+  spanSmall?: boolean;
+}
+
+export type DataTableProps = Omit<TableProps, 'children'> & InternalDataTableProps;
+interface InternalDataTableProps {
+  rows: any[];
+  columns: Column[];
+  multiSelect?: boolean;
+  showEmpty?: boolean;
+  emptyComp?: React.ReactElement<Empty>;
+  onCheck?: (checked: any) => void;
+  responsive?: boolean;
+  smallBreakPoint?: string;
 }

--- a/src/components/Table/TableTypes.tsx
+++ b/src/components/Table/TableTypes.tsx
@@ -30,5 +30,5 @@ interface InternalDataTableProps {
   emptyComp?: React.ReactElement<Empty>;
   onCheck?: (checked: any) => void;
   responsive?: boolean;
-  smallBreakPoint?: string;
+  smallBreakPoint?: number;
 }


### PR DESCRIPTION
### ➕ Added

**DataTable:**
- Added responsive mode to `DataTable`
  - Added `omitFromSmall` prop to `DataTable` column. This will omit the column when rendered on small devices.
  - Added `spanSmall` prop to `DataTable` column. When `true`, this will omit the column header when rendered on small devices and render the value full width.

**Flex:**
- Added `grow` prop to `Flex`

**Overlay**
- Added `onBackgroundClick`

### 📝 Changed

**DataTable:**
- Changed signature for datatable column renderer

**Core:**
- Some minor moves and cleanups

---

Closes #28 